### PR TITLE
Validate CLI Options

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -6,6 +6,7 @@ spark_locals_without_parens = [
   description: 1,
   description: 2,
   doc: 1,
+  example: 1,
   longdoc: 1,
   longdoc: 2,
   required: 1,

--- a/lib/mandate.ex
+++ b/lib/mandate.ex
@@ -27,12 +27,42 @@ defmodule Mandate do
 
       @impl Mix.Task
       def run(argv) do
-        __MODULE__
-        |> Mandate.Info.root()
+        root = Mandate.Info.root(__MODULE__)
+        argv = Mandate.parse_argv!(root, argv)
+
+        root
         |> Enum.find(&is_struct(&1, Mandate.Dsl.Run))
         |> then(fn run -> apply(run.fun, [argv]) end)
       end
     end
+  end
+
+  def parse_argv!(root, argv) do
+    {_switches, pos_args, _err} =
+      OptionParser.parse(argv, strict: [debug: :boolean])
+
+    fields = Enum.filter(root, &is_struct(&1, Mandate.Dsl.Argument))
+    fields_required = Enum.filter(fields, & &1.required)
+
+    pos_args_len = length(pos_args)
+    fields_len = length(fields)
+    fields_required_len = length(fields_required)
+
+    error_message =
+      cond do
+        fields_required_len > pos_args_len ->
+          "Wrong number of required arguments. Expected #{fields_required_len} but got #{pos_args_len}."
+
+        fields_len < pos_args_len ->
+          "Too many arguments. Expected maximum #{fields_len} but got #{pos_args_len}."
+
+        true ->
+          nil
+      end
+
+    if is_binary(error_message), do: raise(error_message)
+
+    pos_args
   end
 
   @doc """

--- a/lib/mandate.ex
+++ b/lib/mandate.ex
@@ -16,53 +16,9 @@ defmodule Mandate do
   @impl Spark.Dsl
   def handle_opts(opts) do
     case Keyword.get(opts, :as) do
-      :mix_task -> mix_task()
+      :mix_task -> Mandate.MixTask.init()
       _ -> quote(do: nil)
     end
-  end
-
-  defp mix_task do
-    quote do
-      use Mix.Task
-
-      @impl Mix.Task
-      def run(argv) do
-        root = Mandate.Info.root(__MODULE__)
-        argv = Mandate.parse_argv!(root, argv)
-
-        root
-        |> Enum.find(&is_struct(&1, Mandate.Dsl.Run))
-        |> then(fn run -> apply(run.fun, [argv]) end)
-      end
-    end
-  end
-
-  def parse_argv!(root, argv) do
-    {_switches, pos_args, _err} =
-      OptionParser.parse(argv, strict: [debug: :boolean])
-
-    fields = Enum.filter(root, &is_struct(&1, Mandate.Dsl.Argument))
-    fields_required = Enum.filter(fields, & &1.required)
-
-    pos_args_len = length(pos_args)
-    fields_len = length(fields)
-    fields_required_len = length(fields_required)
-
-    error_message =
-      cond do
-        fields_required_len > pos_args_len ->
-          "Wrong number of required arguments. Expected #{fields_required_len} but got #{pos_args_len}."
-
-        fields_len < pos_args_len ->
-          "Too many arguments. Expected maximum #{fields_len} but got #{pos_args_len}."
-
-        true ->
-          nil
-      end
-
-    if is_binary(error_message), do: raise(error_message)
-
-    pos_args
   end
 
   @doc """

--- a/lib/mandate.ex
+++ b/lib/mandate.ex
@@ -20,17 +20,4 @@ defmodule Mandate do
       _ -> quote(do: nil)
     end
   end
-
-  @doc """
-  Hello world.
-
-  ## Examples
-
-      iex> Mandate.hello()
-      :world
-
-  """
-  def hello do
-    :world
-  end
 end

--- a/lib/mandate/dsl/argument.ex
+++ b/lib/mandate/dsl/argument.ex
@@ -14,8 +14,8 @@ defmodule Mandate.Dsl.Argument do
           required: true
         ],
         type: [
-          type: :atom,
-          required: true
+          type: {:one_of, [:string, :integer, :float]},
+          default: :string
         ],
         required: [
           type: :boolean,

--- a/lib/mandate/dsl/argument.ex
+++ b/lib/mandate/dsl/argument.ex
@@ -22,7 +22,7 @@ defmodule Mandate.Dsl.Argument do
           default: true
         ],
         example: [
-          type: :string
+          doc: "Example value for the argument"
         ],
         doc: [
           type: :string

--- a/lib/mandate/dsl/argument.ex
+++ b/lib/mandate/dsl/argument.ex
@@ -21,6 +21,9 @@ defmodule Mandate.Dsl.Argument do
           type: :boolean,
           default: true
         ],
+        example: [
+          type: :string
+        ],
         doc: [
           type: :string
         ]

--- a/lib/mandate/dsl/switch.ex
+++ b/lib/mandate/dsl/switch.ex
@@ -16,11 +16,11 @@ defmodule Mandate.Dsl.Switch do
         ],
         type: [
           type: :atom,
-          required: true
+          default: :boolean
         ],
         default: [],
         short: [
-          type: :string
+          type: :atom
         ],
         required: [
           type: :boolean,

--- a/lib/mandate/mix_task.ex
+++ b/lib/mandate/mix_task.ex
@@ -22,28 +22,80 @@ defmodule Mandate.MixTask do
   end
 
   def parse_argv(root, argv) do
-    {_switches, pos_args, _err} =
-      OptionParser.parse(argv, strict: [debug: :boolean])
+    parsed_argv = OptionParser.parse(argv, parse_opts(root))
 
-    pos_args_shema = Enum.filter(root, &is_struct(&1, Mandate.Dsl.Argument))
-    pos_args_shema_required = Enum.filter(pos_args_shema, & &1.required)
+    with {:ok, switches} <- validate_switches(parsed_argv),
+         {:ok, pos_args} <- validate_pos_args(root, parsed_argv) do
+      {:ok, pos_args ++ switches}
+    end
+  end
+
+  defp validate_switches({switches, _pos_args, []}), do: {:ok, switches}
+
+  defp validate_switches({_switches, _pos_args, invalid}),
+    do: {:error, "Invalid options: #{inspect(invalid)}"}
+
+  defp validate_pos_args(root, {_, pos_args, _}) do
+    pos_args_schema = Enum.filter(root, &is_struct(&1, Mandate.Dsl.Argument))
+    pos_args_schema_required = Enum.filter(pos_args_schema, & &1.required)
 
     pos_args_len = length(pos_args)
-    pos_args_schema_len = length(pos_args_shema)
-    pos_args_shema_required_len = length(pos_args_shema_required)
+    pos_args_schema_len = length(pos_args_schema)
+    pos_args_schema_required_len = length(pos_args_schema_required)
 
-    error_message =
-      cond do
-        pos_args_shema_required_len > pos_args_len ->
-          "Wrong number of required arguments. Expected #{pos_args_shema_required_len} but got #{pos_args_len}."
+    with :ok <- validate_required_pos_args(pos_args_schema_required_len, pos_args_len),
+         :ok <- validate_pos_args_len(pos_args_len, pos_args_schema_len) do
+      pos_args =
+        pos_args
+        |> Enum.zip(pos_args_schema)
+        |> Enum.map(&parse_pos_arg/1)
 
-        pos_args_schema_len < pos_args_len ->
-          "Too many arguments. Expected maximum #{pos_args_schema_len} but got #{pos_args_len}."
+      {:ok, pos_args}
+    end
+  end
 
-        true ->
-          nil
+  defp parse_pos_arg({arg, schema}) do
+    value =
+      case schema.type do
+        :string -> arg
+        :integer -> String.to_integer(arg)
+        :float -> String.to_float(arg)
       end
 
-    if is_binary(error_message), do: {:error, error_message}, else: {:ok, pos_args}
+    {schema.name, value}
+  end
+
+  defp validate_required_pos_args(pos_args_schema_required_len, pos_args_len) do
+    if pos_args_schema_required_len > pos_args_len do
+      {:error,
+       "Wrong number of required arguments. Expected #{pos_args_schema_required_len} but got #{pos_args_len}."}
+    else
+      :ok
+    end
+  end
+
+  defp validate_pos_args_len(pos_args_len, max) do
+    if pos_args_len > max do
+      {:error, "Too many arguments. Expected maximum #{max} but got #{pos_args_len}."}
+    else
+      :ok
+    end
+  end
+
+  defp parse_opts(root) do
+    root
+    |> Enum.filter(&is_struct(&1, Mandate.Dsl.Switch))
+    |> Enum.reduce([aliases: [], strict: []], fn switch, [aliases: aliases, strict: strict] ->
+      strict = [{switch.name, switch.type} | strict]
+
+      aliases =
+        if switch.short do
+          [{switch.short, switch.name} | aliases]
+        else
+          aliases
+        end
+
+      [aliases: aliases, strict: strict]
+    end)
   end
 end

--- a/lib/mandate/mix_task.ex
+++ b/lib/mandate/mix_task.ex
@@ -1,0 +1,45 @@
+defmodule Mandate.MixTask do
+  def init do
+    quote do
+      use Mix.Task
+
+      @impl Mix.Task
+      def run(argv) do
+        root = Mandate.Info.root(__MODULE__)
+        argv = Mandate.MixTask.parse_argv!(root, argv)
+
+        root
+        |> Enum.find(&is_struct(&1, Mandate.Dsl.Run))
+        |> then(fn run -> apply(run.fun, [argv]) end)
+      end
+    end
+  end
+
+  def parse_argv!(root, argv) do
+    {_switches, pos_args, _err} =
+      OptionParser.parse(argv, strict: [debug: :boolean])
+
+    fields = Enum.filter(root, &is_struct(&1, Mandate.Dsl.Argument))
+    fields_required = Enum.filter(fields, & &1.required)
+
+    pos_args_len = length(pos_args)
+    fields_len = length(fields)
+    fields_required_len = length(fields_required)
+
+    error_message =
+      cond do
+        fields_required_len > pos_args_len ->
+          "Wrong number of required arguments. Expected #{fields_required_len} but got #{pos_args_len}."
+
+        fields_len < pos_args_len ->
+          "Too many arguments. Expected maximum #{fields_len} but got #{pos_args_len}."
+
+        true ->
+          nil
+      end
+
+    if is_binary(error_message), do: raise(error_message)
+
+    pos_args
+  end
+end

--- a/lib/mandate/mix_task.ex
+++ b/lib/mandate/mix_task.ex
@@ -25,20 +25,20 @@ defmodule Mandate.MixTask do
     {_switches, pos_args, _err} =
       OptionParser.parse(argv, strict: [debug: :boolean])
 
-    fields = Enum.filter(root, &is_struct(&1, Mandate.Dsl.Argument))
-    fields_required = Enum.filter(fields, & &1.required)
+    pos_args_shema = Enum.filter(root, &is_struct(&1, Mandate.Dsl.Argument))
+    pos_args_shema_required = Enum.filter(pos_args_shema, & &1.required)
 
     pos_args_len = length(pos_args)
-    fields_len = length(fields)
-    fields_required_len = length(fields_required)
+    pos_args_schema_len = length(pos_args_shema)
+    pos_args_shema_required_len = length(pos_args_shema_required)
 
     error_message =
       cond do
-        fields_required_len > pos_args_len ->
-          "Wrong number of required arguments. Expected #{fields_required_len} but got #{pos_args_len}."
+        pos_args_shema_required_len > pos_args_len ->
+          "Wrong number of required arguments. Expected #{pos_args_shema_required_len} but got #{pos_args_len}."
 
-        fields_len < pos_args_len ->
-          "Too many arguments. Expected maximum #{fields_len} but got #{pos_args_len}."
+        pos_args_schema_len < pos_args_len ->
+          "Too many arguments. Expected maximum #{pos_args_schema_len} but got #{pos_args_len}."
 
         true ->
           nil

--- a/lib/mandate/verifiers/verify_required.ex
+++ b/lib/mandate/verifiers/verify_required.ex
@@ -11,7 +11,9 @@ defmodule Mandate.Verifiers.VerifyRequired do
   end
 
   defp verify_run(dsl_state) do
-    if Enum.any?(get_entities(dsl_state), &is_struct(&1, Mandate.Dsl.Run)) do
+    entities = get_entities(dsl_state)
+
+    if Enum.any?(entities, &is_struct(&1, Mandate.Dsl.Run)) do
       :ok
     else
       message = """
@@ -20,15 +22,20 @@ defmodule Mandate.Verifiers.VerifyRequired do
           run fn args ->
             IO.puts("Running my task  with: \#{inspect(args)}"
           end
+
       """
 
-      {:error,
-       DslError.exception(
-         message: message,
-         module: Spark.Dsl.Verifier.get_persisted(dsl_state, :module),
-         path: [:root, :entities, :run]
-       )}
+      build_error(dsl_state, message, [:root, :entities, :run])
     end
+  end
+
+  defp build_error(state, message, path) do
+    {:error,
+     DslError.exception(
+       message: message,
+       module: Spark.Dsl.Verifier.get_persisted(state, :module),
+       path: path
+     )}
   end
 
   defp get_entities(dsl_state) do

--- a/lib/mix/tasks/mandate.gen.mix_task.ex
+++ b/lib/mix/tasks/mandate.gen.mix_task.ex
@@ -9,7 +9,13 @@ defmodule Mix.Tasks.Mandate.Gen.MixTask do
     required true
   end
 
+  argument :my_number, :integer do
+    doc "Any number"
+    example 42
+  end
+
   run fn args ->
-    IO.puts("Running my_task  with: #{inspect(args)}")
+    name = Mix.Task.task_name(__MODULE__)
+    IO.puts("Running `#{name}` with: #{inspect(args)}")
   end
 end

--- a/lib/mix/tasks/mandate.gen.mix_task.ex
+++ b/lib/mix/tasks/mandate.gen.mix_task.ex
@@ -4,18 +4,24 @@ defmodule Mix.Tasks.Mandate.Gen.MixTask do
   shortdoc "Generates a new Mix Task"
   longdoc "Generates a new Mix Task, accepts arguments"
 
-  argument :name, :string do
+  argument :name do
     doc "Task name. Example: `my_app.my_task`"
     required true
   end
 
-  argument :my_number, :integer do
+  argument :my_number, :float do
     doc "Any number"
-    example 42
+    example 42.42
   end
 
-  run fn args ->
+  switch :help, short: :h
+
+  switch :pin, :integer do
+    short :p
+  end
+
+  run fn options ->
     name = Mix.Task.task_name(__MODULE__)
-    Mix.shell().info("Running `#{name}` with: #{inspect(args)}")
+    Mix.shell().info("Running `#{name}` with: #{inspect(options)}")
   end
 end

--- a/lib/mix/tasks/mandate.gen.mix_task.ex
+++ b/lib/mix/tasks/mandate.gen.mix_task.ex
@@ -16,6 +16,6 @@ defmodule Mix.Tasks.Mandate.Gen.MixTask do
 
   run fn args ->
     name = Mix.Task.task_name(__MODULE__)
-    IO.puts("Running `#{name}` with: #{inspect(args)}")
+    Mix.shell().info("Running `#{name}` with: #{inspect(args)}")
   end
 end

--- a/test/mandate_test.exs
+++ b/test/mandate_test.exs
@@ -1,8 +1,4 @@
 defmodule MandateTest do
   use ExUnit.Case
   doctest Mandate
-
-  test "greets the world" do
-    assert Mandate.hello() == :world
-  end
 end

--- a/test/mix/tasks/mandate.gen.mix_task_test.exs
+++ b/test/mix/tasks/mandate.gen.mix_task_test.exs
@@ -1,13 +1,20 @@
 defmodule Mix.Tasks.Mandate.Gen.MixTaskTest do
   use ExUnit.Case, async: true
   alias Mix.Tasks.Mandate.Gen.MixTask
+  import ExUnit.CaptureIO
 
   @task_name "mandate.gen.mix_task"
+
+  test "is a mix task" do
+    assert Mix.Task.task?(MixTask)
+    assert @task_name == Mix.Task.task_name(MixTask)
+  end
 
   test "inject @shortdoc" do
     attributes = MixTask.__info__(:attributes)
 
-    assert ["Generates a new Mix Task"] = Keyword.get(attributes, :shortdoc)
+    assert ["Generates a new Mix Task"] == Keyword.get(attributes, :shortdoc)
+    assert "Generates a new Mix Task" == Mix.Task.shortdoc(MixTask)
   end
 
   test "inject @moduledoc" do
@@ -22,20 +29,22 @@ defmodule Mix.Tasks.Mandate.Gen.MixTaskTest do
       Mix.Task.reenable(@task_name)
     end
 
-    test "xxxx" do
-      msg = "Too many arguments. Expected maximum 1 but got 4."
+    test "Too many arguments" do
+      output =
+        capture_io(:stderr, fn ->
+          Mix.Task.run(@task_name, ["one", "s", "sdds", "sds"])
+        end)
 
-      assert_raise RuntimeError, msg, fn ->
-        Mix.Task.run(@task_name, ["one", "s", "sdds", "sds"])
-      end
+      assert output =~ "Too many arguments. Expected maximum 1 but got 4."
     end
 
     test "Required arguments presence." do
-      msg = "Wrong number of required arguments. Expected 1 but got 0."
+      output =
+        capture_io(:stderr, fn ->
+          Mix.Task.run(@task_name, [])
+        end)
 
-      assert_raise RuntimeError, msg, fn ->
-        Mix.Task.run(@task_name, [])
-      end
+      assert output =~ "Wrong number of required arguments. Expected 1 but got 0."
     end
   end
 end

--- a/test/mix/tasks/mandate.gen.mix_task_test.exs
+++ b/test/mix/tasks/mandate.gen.mix_task_test.exs
@@ -35,7 +35,7 @@ defmodule Mix.Tasks.Mandate.Gen.MixTaskTest do
           Mix.Task.run(@task_name, ["one", "s", "sdds", "sds"])
         end)
 
-      assert output =~ "Too many arguments. Expected maximum 1 but got 4."
+      assert output =~ "Too many arguments. Expected maximum 2 but got 4."
     end
 
     test "Required arguments presence." do
@@ -44,7 +44,7 @@ defmodule Mix.Tasks.Mandate.Gen.MixTaskTest do
           Mix.Task.run(@task_name, [])
         end)
 
-      assert output =~ "Wrong number of required arguments. Expected 1 but got 0."
+      assert output =~ "Wrong number of required arguments. Expected 2 but got 0."
     end
   end
 end

--- a/test/mix/tasks/mandate.gen.mix_task_test.exs
+++ b/test/mix/tasks/mandate.gen.mix_task_test.exs
@@ -2,62 +2,40 @@ defmodule Mix.Tasks.Mandate.Gen.MixTaskTest do
   use ExUnit.Case, async: true
   alias Mix.Tasks.Mandate.Gen.MixTask
 
+  @task_name "mandate.gen.mix_task"
+
   test "inject @shortdoc" do
     attributes = MixTask.__info__(:attributes)
 
     assert ["Generates a new Mix Task"] = Keyword.get(attributes, :shortdoc)
   end
 
-  # test "inject @moduledoc" do
-  #   attributes = MixTask.__info__(:attributes)
+  test "inject @moduledoc" do
+    attributes = MixTask.__info__(:attributes)
 
-  #   assert ["Generates a new Mix Task"] = Keyword.get(attributes, :moduledoc)
-  # end
+    assert [{1, text} | _] = Keyword.get(attributes, :moduledoc)
+    assert text =~ "accepts arguments"
+  end
 
-  # test "mandate.gen.mix_task" do
-  #   args = []
+  describe "mix task run" do
+    setup do
+      Mix.Task.reenable(@task_name)
+    end
 
-  #   Mix.Task.run("mandate.gen.mix_task", args)
-  # end
+    test "xxxx" do
+      msg = "Too many arguments. Expected maximum 1 but got 4."
 
-  # describe "run/1" do
-  #   setup context do
-  #     Gen.run(context[:argv])
+      assert_raise RuntimeError, msg, fn ->
+        Mix.Task.run(@task_name, ["one", "s", "sdds", "sds"])
+      end
+    end
 
-  #     Mix.Task.run("mandate.gen.mix_task", context[:argv])
+    test "Required arguments presence." do
+      msg = "Wrong number of required arguments. Expected 1 but got 0."
 
-  #     assert_received {:mix_shell, :info, [jwt]}
-
-  #     # token = Cerebro.Jwt.verify_jwt(jwt)
-
-  #     {:ok, claims: token.claims, token: token}
-  #     {:ok, claims: token.claims, token: token}
-  #   end
-
-  #   @tag argv: []
-  #   test "prints a valid JWT with no args", %{token: token} do
-  #     jwt
-  #     refute token.error
-  #   end
-
-  # @tag argv: ["--exp", "123"]
-  # test "prints a valid JWT when passed an expiration", %{claims: claims} do
-  #   assert_in_delta claims["exp"], Joken.current_time(), 124
-  # end
-
-  # @tag argv: ["--jti", "fdsa"]
-  # test "prints a valid JWT when passed a jti", %{claims: claims} do
-  #   assert claims["jti"] == "fdsa"
-  # end
-
-  # @tag argv: ["--iss", "logan"]
-  # test "prints a valid JWT when passed an iss", %{claims: claims} do
-  #   assert claims["iss"] == "logan"
-  # end
-
-  # @tag argv: ["--token", "asdf"]
-  # test "prints a valid JWT when passed a token", %{claims: claims} do
-  #   assert claims["token"] == "asdf"
-  # end
-  # end
+      assert_raise RuntimeError, msg, fn ->
+        Mix.Task.run(@task_name, [])
+      end
+    end
+  end
 end


### PR DESCRIPTION

- **feat: Add parse_argv! to mandate.ex and tests for mix task arguments**
- **refactor: Move mix task implementation to Mandate.MixTask module**
- **chore: Remove Mandate.hello/0**
- **refactor: Refactor Mandate.MixTask to return error tuples**
- **test: Improve error message tests for mix task generator**
- **feat: Add example and doc to argument DSL**
- **fix: Fix argument length validation and task output message.**
- **feat: Refactor mandate mix task to use OptionParser and add switches**
